### PR TITLE
fixed typo

### DIFF
--- a/initialize_parameters.yml
+++ b/initialize_parameters.yml
@@ -115,12 +115,4 @@ Resources:
       Type: String
       Value: default
 
-  EventBusArnParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Description: ARN of EventBus.
-      Name: EventBusArn
-      Type: String
-      Value: !Sub arn:aws:events:{{AWS::Region}}:{{AWS::Account}}:event-bus/default
-
 

--- a/initialize_parameters.yml
+++ b/initialize_parameters.yml
@@ -115,4 +115,12 @@ Resources:
       Type: String
       Value: default
 
+  EventBusArnParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: ARN of EventBus.
+      Name: EventBusArn
+      Type: String
+      Value: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
+
 


### PR DESCRIPTION
Parameter value: 'arn:aws:events:{{AWS::Region}}:{{AWS::Account}}:event-bus/default' failed to satisfy constraint: Parameter value can't nest another parameter. Do not use "{{}}" in the value. (Service: AmazonSSM; Status Code: 400; Error Code: ValidationException; Request ID: df7f8ce9-a4c4-4cae-8b50-118a96849dd9; Proxy: null)